### PR TITLE
Docker: Add uswgi_*_timeout env var for the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,19 @@ this is the easiest way to get a pastefile application running quickly.
 
 # Options
 
-|Parameters       | Usage                                                                                                                                      |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-|UPLOAD_FOLDER    | Where the files are stored.                                                                                                                |
-|FILE_LIST        | The file that act as the db (jsondb)                                                                                                       |
-|TMP_FOLDER       | The folder where the files are stored during the transfer                                                                                  |
-|EXPIRE           | How many long the files are stored (in seconds)                                                                                            |
-|DEBUG_PORT       | The port used for debugging mode                                                                                                           |
-|LOG              | The path to the log file                                                                                                                   |
-|DISABLED_FEATURE | List of features you want to disable. Allowed value : `delete`, `ls`                                                                       |
-|DISPLAY_FOR      | Display file like png or txt directly in your browser instead of asking for download. Allowed list from flask `request.user_agent.browser` |
+|Parameters              | Usage                                                                                                                                                                                       |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|UPLOAD_FOLDER           | Where the files are stored.                                                                                                                                                                 |
+|FILE_LIST               | The file that act as the db (jsondb)                                                                                                                                                        |
+|TMP_FOLDER              | The folder where the files are stored during the transfer                                                                                                                                   |
+|EXPIRE                  | How many long the files are stored (in seconds)                                                                                                                                             |
+|DEBUG_PORT              | The port used for debugging mode                                                                                                                                                            |
+|LOG                     | The path to the log file                                                                                                                                                                    |
+|DISABLED_FEATURE        | List of features you want to disable. Allowed value : `delete`, `ls`                                                                                                                        |
+|DISPLAY_FOR             | Display file like png or txt directly in your browser instead of asking for download. Allowed list from flask `request.user_agent.browser`                                                  |
+|UWSGI_CONNECT_TIMEOUT   | Defines a timeout for establishing a connection with a uwsgi server. Default 60s                                                                                                            |
+|UWSGI_READ_TIMEOUT      | Defines a timeout for reading a response from the uwsgi server. The timeout is set only between two successive read operations, not for the transmission of the whole response. Default 60s |
+|UWSGI_SEND_TIMEOUT      | Sets a timeout for transmitting a request to the uwsgi server. The timeout is set only between two successive write operations, not for the transmission of the whole request. Default 60s  |
 
 > **Note**:
 

--- a/extra/Docker/configs/vhost.conf.template
+++ b/extra/Docker/configs/vhost.conf.template
@@ -7,6 +7,9 @@ server {
 
         location @${NGINX_APP_NAME} {
             include uwsgi_params;
+            uwsgi_connect_timeout ${UWSGI_CONNECT_TIMEOUT};
+            uwsgi_read_timeout ${UWSGI_READ_TIMEOUT};
+            uwsgi_send_timeout ${UWSGI_SEND_TIMEOUT};
             uwsgi_pass unix://${UWSGI_SOCK};
         }
 }

--- a/extra/Docker/scripts/entrypoint
+++ b/extra/Docker/scripts/entrypoint
@@ -8,7 +8,12 @@
 [ -z $UWSGI_SOCK ] && export UWSGI_SOCK=/tmp/uwsgi.sock
 [ -z $MAX_FILE_SIZE ] && export MAX_FILE_SIZE=1G
 
+# Doc http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html
+[ -z $UWSGI_CONNECT_TIMEOUT ] && export UWSGI_CONNECT_TIMEOUT=60s
+[ -z $UWSGI_READ_TIMEOUT ] && export UWSGI_READ_TIMEOUT=60s
+[ -z $UWSGI_SEND_TIMEOUT ] && export UWSGI_SEND_TIMEOUT=60s
+
 envsubst '$NGINX_WORKER_PROCESSES $NGINX_WORKER_CONNECTIONS $NGINX_KEEPALIVE_TIMEOUT' < /opt/pastefile/nginx.conf.template > /etc/nginx/nginx.conf
-envsubst '$NGINX_DEFAULT_PORT $NGINX_APP_NAME $UWSGI_SOCK $MAX_FILE_SIZE' < /opt/pastefile/vhost.conf.template > /etc/nginx/conf.d/pastefile.conf
+envsubst '$UWSGI_CONNECT_TIMEOUT $UWSGI_READ_TIMEOUT $UWSGI_SEND_TIMEOUT $NGINX_DEFAULT_PORT $NGINX_APP_NAME $UWSGI_SOCK $MAX_FILE_SIZE' < /opt/pastefile/vhost.conf.template > /etc/nginx/conf.d/pastefile.conf
 nginx
 exec uwsgi -s $UWSGI_SOCK -w pastefile.app:app --chdir /var/www/pastefile --uid 33 --gid 33 --env PASTEFILE_SETTINGS=/etc/pastefile.cfg --enable-threads


### PR DESCRIPTION
From http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html

Add new env vars to be able to override uwsgi timeout for nginx vhost.