### PR TITLE
docker: use environment variables for docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN chown -R www-data:www-data /opt/pastefile
 
 COPY ./extra/Docker/configs/nginx.conf.template /opt/pastefile/nginx.conf.template
 COPY ./extra/Docker/configs/vhost.conf.template /opt/pastefile/vhost.conf.template
-COPY ./extra/Docker/configs/pastefile.cfg.template /etc/pastefile.cfg
 COPY ./extra/Docker/scripts/entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]

--- a/extra/Docker/configs/pastefile.cfg.template
+++ b/extra/Docker/configs/pastefile.cfg.template
@@ -1,7 +1,0 @@
-HOSTNAME = "pastefile.fr"
-UPLOAD_FOLDER = "/opt/pastefile/files/"
-FILE_LIST = "/opt/pastefile/uploaded_files_jsondb"
-TMP_FOLDER = "/opt/pastefile/tmp"
-EXPIRE = 86400
-DEBUG_PORT = 5000
-LOG = "/tmp/pastefile.log"

--- a/extra/Docker/scripts/entrypoint
+++ b/extra/Docker/scripts/entrypoint
@@ -13,7 +13,31 @@
 [ -z $UWSGI_READ_TIMEOUT ] && export UWSGI_READ_TIMEOUT=60s
 [ -z $UWSGI_SEND_TIMEOUT ] && export UWSGI_SEND_TIMEOUT=60s
 
+[ -z $HOSTNAME ] && export HOSTNAME="pastefile.fr"
+[ -z $UPLOAD_FOLDER ] && export UPLOAD_FOLDER="/opt/pastefile/files"
+[ -z $FILE_LIST ] && export FILE_LIST="/opt/pastefile/pastefile.db"
+[ -z $TMP_FOLDER ] && export TMP_FOLDER="/opt/pastefile/tmp"
+[ -z $EXPIRE ] && export EXPIRE="1209600"
+[ -z $DEBUG_PORT ] && export DEBUG_PORT=5000
+[ -z $LOG ] $$ export LOG="/opt/pastefile/pastefile.log"
+[ -z $DISABLED_FEATURE ] && DISABLED_FEATURE="[ 'ls' ]"
+[ -z $DISPLAY_FOR ] && DISPLAY_FOR="['chrome', 'firefor']"
+
 envsubst '$NGINX_WORKER_PROCESSES $NGINX_WORKER_CONNECTIONS $NGINX_KEEPALIVE_TIMEOUT' < /opt/pastefile/nginx.conf.template > /etc/nginx/nginx.conf
 envsubst '$UWSGI_CONNECT_TIMEOUT $UWSGI_READ_TIMEOUT $UWSGI_SEND_TIMEOUT $NGINX_DEFAULT_PORT $NGINX_APP_NAME $UWSGI_SOCK $MAX_FILE_SIZE' < /opt/pastefile/vhost.conf.template > /etc/nginx/conf.d/pastefile.conf
 nginx
-exec uwsgi -s $UWSGI_SOCK -w pastefile.app:app --chdir /var/www/pastefile --uid 33 --gid 33 --env PASTEFILE_SETTINGS=/etc/pastefile.cfg --enable-threads
+
+exec uwsgi -s $UWSGI_SOCK \
+-w pastefile.app:app \
+--chdir /var/www/pastefile \
+--uid 33 --gid 33 \
+--env HOSTNAME=$HOSTNAME \
+--env UPLOAD_FOLDER=$UPLOAD_FOLDER \
+--env FILE_LIST=$FILE_LIST \
+--env TMP_FOLDER=$TMP_FOLDER \
+--env EXPIRE=$EXPIRE \
+--env DEBUG_PORT=$DEBUG_PORT \
+--env LOG=$LOG \
+--env DISABLED_FEATURE=$DISABLED_FEATURE \
+--env DISPLAY_FOR=$DISPLAY_FOR \
+--enable-threads

--- a/extra/uwsgi_pastefile.ini
+++ b/extra/uwsgi_pastefile.ini
@@ -4,6 +4,5 @@ module = app:app
 chdir  = /var/www/pastefile/pastefile
 uid = 33
 gid = 33
-env = PASTEFILE_SETTINGS=/etc/pastefile.cfg
 processes = 1
 threads = 1


### PR DESCRIPTION
use environment variables for docker since `1d8ff2a` provides this
capability.