### PR TITLE
requirements: Change uWSGI version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.10.1
 python-magic==0.4.10
-uWSGI==2.0.11.2
+uWSGI==2.0.13


### PR DESCRIPTION
Change uWSGI version requirement from 2.0.11.2 to 2.0.13

This change is needed to be able to install pastefile on RedHat
distribution family.

uWSGI > 2.0.11 can't be compiled with GCC6 which comes with last
releases of Fedora or CentOS.