### PR TITLE
fix #14: Burn_after_read. We reupload a file already burned after read, the file is unaccessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ this is the easiest way to get a pastefile application running quickly.
 > if the parameter is a string, you must quote it with **""**
 
 
+> **Optimize** : Pastefile use `shutil.move`. To improve performance we recommand you to use the same filesystem for `TMP_FOLDER` and `UPLOAD_FOLDER` to allow rename file instead of file copy.
+
 # Usage
 Upload a file:
 ```bash
@@ -187,7 +189,7 @@ curl -F file=@</path/to/the/file> http://pastefile.fr
 
 Upload a file with burn after read :
 ```bash
-curl -F file=@</path/to/the/file> -F burn=truehttp://pastefile.fr
+curl -F file=@</path/to/the/file> -F burn=true http://pastefile.fr
 ```
 
 View all uploaded files:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Upload a file:
 curl -F file=@</path/to/the/file> http://pastefile.fr
 ```
 
+Upload a file with burn after read :
+```bash
+curl -F file=@</path/to/the/file> -F burn=truehttp://pastefile.fr
+```
+
 View all uploaded files:
 ```bash
 curl http://pastefile.fr/ls

--- a/pastefile/app.py
+++ b/pastefile/app.py
@@ -174,6 +174,7 @@ def page_not_found(e):
 
     helps = (
         ("Upload a file:", "curl %s -F file=@**filename**" % base_url),
+        ("Upload a file with burn after read:", "curl %s -F burn=true -F file=@**filename**" % base_url),
         ("View all uploaded files:", "curl %s/ls" % base_url),
         ("Get infos about one file:", "curl %s/**file_id**/infos" % base_url),
         ("Get a file:", "curl -JO %s/**file_id**" % base_url),

--- a/pastefile/app.py
+++ b/pastefile/app.py
@@ -174,13 +174,14 @@ def page_not_found(e):
 
     helps = (
         ("Upload a file:", "curl %s -F file=@**filename**" % base_url),
-        ("Upload a file with burn after read:", "curl %s -F burn=true -F file=@**filename**" % base_url),
+        ("Upload a file with burn after read:",
+            "curl %s -F burn=true -F file=@**filename**" % base_url),
         ("View all uploaded files:", "curl %s/ls" % base_url),
         ("Get infos about one file:", "curl %s/**file_id**/infos" % base_url),
         ("Get a file:", "curl -JO %s/**file_id**" % base_url),
         ("Delete a file:", "curl -XDELETE %s/**id**" % base_url),
         ("Create an alias for cli usage",
-         'pastefile() { curl -F file=@"$1" %s; }' % base_url),
+            'pastefile() { curl -F file=@"$1" %s; }' % base_url),
     )
     context = {'user_agent': request.headers.get('User-Agent', ''),
                'helps': helps}

--- a/pastefile/jsondb.py
+++ b/pastefile/jsondb.py
@@ -5,6 +5,7 @@ import logging
 import fcntl
 import time
 import os
+from shutil import move
 
 
 def timeout(timeout=3, start=None):
@@ -67,7 +68,7 @@ class JsonDB(object):
         try:
             tmp_file = '%s.atomic' % self._dbfile
             json.dump(self.db, open(tmp_file, 'w'))
-            os.rename(tmp_file, self._dbfile)
+            move(tmp_file, self._dbfile)
         except OSError as e:
             self._logger.error('Error while saving the db: %s' % e)
 

--- a/pastefile/jsondb.py
+++ b/pastefile/jsondb.py
@@ -4,7 +4,6 @@ import json
 import logging
 import fcntl
 import time
-import os
 from shutil import move
 
 

--- a/pastefile/tests/test_functional.py
+++ b/pastefile/tests/test_functional.py
@@ -273,7 +273,7 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.post('/', data={'file': (open(_file, 'r'),
                            'test_pastefile_random.file'), 'burn': 'True', })
 
-		# Check if the flag burn is set on the file
+        # Check if the flag burn is set on the file
         rv = self.app.get('/%s/infos' % test_md5, headers={'User-Agent': 'curl'})
         rv_json = json.loads(rv.get_data())
         self.assertEquals(rv_json['burn_after_read'], 'True')

--- a/pastefile/tests/test_functional.py
+++ b/pastefile/tests/test_functional.py
@@ -274,7 +274,8 @@ class FlaskrTestCase(unittest.TestCase):
                            'test_pastefile_random.file'), 'burn': 'True', })
 
         # Check if the flag burn is set on the file
-        rv = self.app.get('/%s/infos' % test_md5, headers={'User-Agent': 'curl'})
+        rv = self.app.get('/%s/infos' % test_md5,
+                          headers={'User-Agent': 'curl'})
         rv_json = json.loads(rv.get_data())
         self.assertEquals(rv_json['burn_after_read'], 'True')
 
@@ -297,16 +298,18 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.get('/%s' % test_md5, headers={'User-Agent': 'curl'})
         self.assertEquals(rv.status, '404 NOT FOUND')
 
-		# This should file should have a burned flag
-        rv = self.app.get('/%s/infos' % test_md5, headers={'User-Agent': 'curl'})
+        # This should file should have a burned flag
+        rv = self.app.get('/%s/infos' % test_md5,
+                          headers={'User-Agent': 'curl'})
         rv_json = json.loads(rv.get_data())
         self.assertEquals(rv_json['burn_after_read'], 'Burned')
 
-        ## Upload the file again, it should be unburned
+        # Upload the file again, it should be unburned
         rv = self.app.post('/', data={'file': (open(_file, 'r'),
                            'test_pastefile_random.file'), 'burn': 'True', })
 
-        rv = self.app.get('/%s/infos' % test_md5, headers={'User-Agent': 'curl'})
+        rv = self.app.get('/%s/infos' % test_md5,
+                          headers={'User-Agent': 'curl'})
         rv_json = json.loads(rv.get_data())
         self.assertEquals(rv_json['burn_after_read'], 'True')
 
@@ -314,10 +317,10 @@ class FlaskrTestCase(unittest.TestCase):
         rv = self.app.post('/', data={'file': (open(_file, 'r'),
                            'test_pastefile_random.file'), 'burn': 'False', })
 
-        rv = self.app.get('/%s/infos' % test_md5, headers={'User-Agent': 'curl'})
+        rv = self.app.get('/%s/infos' % test_md5,
+                          headers={'User-Agent': 'curl'})
         rv_json = json.loads(rv.get_data())
         self.assertEquals(rv_json['burn_after_read'], 'False')
-
 
     def test_check_db_consistency(self):
         # This feature is not yet implemented


### PR DESCRIPTION

Now db informations on a file is refresh at each upload. Even if the file already exist.

This commit also improve the fix https://github.com/guits/pastefile/pull/66
about the cross filesystem move `Error while saving the db: [Errno 18] Invalid cross-device link`

`shutil.move` take the best of this issue `If the destination is on the current filesystem, then os.rename() is used. Otherwise, src is copied (using shutil.copy2()) to dst and then removed.`

The last modification concern flag for `burn_after_read`. The html post value is now a boolean.

That's allow us to put true or false inside. Instead of taking as true if the string is not empty
