### PR TITLE
tests/pep8: Change max line length from 80 to 100 chars

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ setenv =
   PASTEFILE_SETTINGS=../pastefile-test.cfg
 commands =
     nosetests -v {posargs}
-    flake8 pastefile
+    flake8 --max-line-length=100 pastefile


### PR DESCRIPTION
Change max line length from 80 to 100 chars